### PR TITLE
fix: avoid mobile select hydration mismatch

### DIFF
--- a/components/ui/SelectDropdown.tsx
+++ b/components/ui/SelectDropdown.tsx
@@ -142,7 +142,7 @@ export function SelectDropdown({
         onKeyDown={handleTriggerKeyDown}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
-        aria-controls={listboxId}
+        aria-controls={isOpen ? listboxId : undefined}
         className={cn(
           "w-full bg-bg-secondary text-text-primary border border-border-default rounded-md pl-3 pr-8 py-2 text-sm text-left outline-none focus:border-accent-primary focus-visible:ring-1 focus-visible:ring-accent-primary cursor-pointer transition-colors duration-(--duration-short)",
           triggerClassName

--- a/components/ui/__tests__/SelectDropdown.test.tsx
+++ b/components/ui/__tests__/SelectDropdown.test.tsx
@@ -28,6 +28,20 @@ describe("SelectDropdown", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("only links the trigger to the listbox while open", async () => {
+    const user = userEvent.setup();
+    render(<ControlledSelect />);
+
+    const trigger = screen.getByRole("button", { name: "One" });
+    expect(trigger).not.toHaveAttribute("aria-controls");
+
+    await user.click(trigger);
+
+    const listboxId = trigger.getAttribute("aria-controls");
+    expect(listboxId).toBeTruthy();
+    expect(document.getElementById(listboxId ?? "")).toBeInTheDocument();
+  });
+
   it("supports keyboard listbox navigation", async () => {
     const user = userEvent.setup();
     render(<ControlledSelect />);


### PR DESCRIPTION
## Summary
- avoid rendering aria-controls on closed SelectDropdown triggers
- keep aria-controls linked to the listbox only while the dropdown is open
- add SelectDropdown coverage for the closed/open aria-controls behavior

## Validation
- npm.cmd run test -- components/ui/__tests__/SelectDropdown.test.tsx
- npm.cmd run lint
- MCP mobile Text page check at 390x844: no hydration console error